### PR TITLE
Fix template response order

### DIFF
--- a/src/xtend/views.py
+++ b/src/xtend/views.py
@@ -166,8 +166,8 @@ async def stream_page(request: Request, session_id: str):
     if session_id not in app_sessions:
         logger.error("Invalid session ID: %s requested for streaming.", session_id)
         return templates.TemplateResponse(
+            "session_expired.html",
             {"request": request, "session_id": session_id},
-            "session_expired.html"
         )
 
     logger.info("Starting video feed for session ID: %s", session_id)


### PR DESCRIPTION
## Summary
- fix argument order for invalid session template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f3d04b6608323905cfac0cb8918e6