### PR TITLE
Fix template order and test invalid session

### DIFF
--- a/src/xtend/views.py
+++ b/src/xtend/views.py
@@ -166,8 +166,8 @@ async def stream_page(request: Request, session_id: str):
     if session_id not in app_sessions:
         logger.error("Invalid session ID: %s requested for streaming.", session_id)
         return templates.TemplateResponse(
+            "session_expired.html",
             {"request": request, "session_id": session_id},
-            "session_expired.html"
         )
 
     logger.info("Starting video feed for session ID: %s", session_id)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,13 @@
+import pytest
+from starlette.testclient import TestClient
+from xtend.app import app, app_sessions
+
+client = TestClient(app)
+
+def test_stream_page_invalid_session_returns_expired_template():
+    session_id = "invalid123"
+    if session_id in app_sessions:
+        del app_sessions[session_id]
+    response = client.get(f"/stream/{session_id}")
+    assert response.status_code == 200
+    assert "session expired" in response.text.lower()


### PR DESCRIPTION
## Summary
- correct argument order in `stream_page` when rendering session-expired template
- add unit test for invalid session template

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_683f403065c08323b9cffd7ac00b06b6